### PR TITLE
Fix ambiguous convert

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -12,6 +12,7 @@ Base.promote_rule(::Type{InfExtended{T}}, ::Type{Infinite}) where {T<:Real} = In
   :(x.signbit ? $mkninf : $mkpinf)
 end
 @generated Base.convert(::Type{T}, x::InfExtended{S}) where {T<:Real,S<:Real} = :(convert($(typeof(convert(T,zero(S)))), x.val))
+Base.convert(::Type{Infinite}, x::InfExtended{T}) where {T<:Real} = isinf(x) ? Infinite(signbit(x)) : throw(InexactError(:convert,Infinite,x))
 Base.convert(::Type{Infinite}, x::Real) = isinf(x) ? Infinite(signbit(x)) : throw(InexactError(:convert,Infinite,x))
 Base.convert(::Type{Infinite}, x::Infinite) = x
 Base.convert(::Type{T}, x::S) where {T<:InfExtended, S<:Real} = T(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,4 +83,8 @@ using Infinity, Infinity.Utils, Test
     @inferred sign(InfExtended{Int32}(∞))
   end
 
+  @testset "conversions" begin
+    @test convert(Infinite, InfExtended{Int}(∞)) === ∞
+  end
+
 end


### PR DESCRIPTION
```julia
julia> using Infinity
[ Info: Precompiling Infinity [a303e19e-6eb4-11e9-3b09-cd9505f79100]

julia> convert(Infinite, InfExtended{Int64}(∞))
ERROR: MethodError: convert(::Type{Infinite}, ::InfExtended{Int64}) is ambiguous. Candidates:
  convert(::Type{Infinite}, x::Real) in Infinity at /Users/omus/.julia/dev/Infinity/src/conversion.jl:15
  convert(::Type{T}, x::InfExtended{S}) where {T<:Real, S<:Real} in Infinity at /Users/omus/.julia/dev/Infinity/src/conversion.jl:14
Possible fix, define
  convert(::Type{Infinite}, ::InfExtended{S<:Real})
Stacktrace:
 [1] top-level scope at REPL[2]:1
```