### PR TITLE
Add `iszero(::Infinite)`

### DIFF
--- a/src/infinite/comparison.jl
+++ b/src/infinite/comparison.jl
@@ -2,6 +2,8 @@ Base.isfinite(x::Infinite) = false
 
 Base.isinf(x::Infinite) = true
 
+Base.iszero(::Infinite) = false
+
 Base.:(==)(x::Infinite, y::Infinite) = x.signbit == y.signbit
 
 Base.hash(x::Infinite, h::UInt) = hash(isposinf(x) ? Inf : -Inf, h)

--- a/test/infextendedreal.jl
+++ b/test/infextendedreal.jl
@@ -81,6 +81,10 @@
         @test !isinf(InfExtendedReal(9))
         @test isinf(InfExtendedReal{Float64}(Inf))
 
+        @test !iszero(InfExtendedReal{Int}(∞))
+        @test iszero(InfExtendedReal(0))
+        @test !iszero(InfExtendedReal{Float64}(Inf))
+
         @test InfExtendedReal(5) == 5
         @test InfExtendedReal(7) == 7.0
         @test InfExtendedReal(4) != InfExtendedReal(1)

--- a/test/infinite.jl
+++ b/test/infinite.jl
@@ -50,6 +50,8 @@
         @test !isfinite(-x)
         @test isinf(x)
         @test isinf(-x)
+        @test !iszero(x)
+        @test !iszero(-x)
         @test x == x
         @test x != -x
         @test hash(x) != hash(-x)


### PR DESCRIPTION
Allows `iszero` to be called on `∞`. Useful for generic programming

```julia
julia> iszero(∞)
ERROR: InexactError: convert(Infinite, 0)
Stacktrace:
 [1] convert(::Type{Infinite}, ::Int64) at /Users/omus/.julia/dev/Infinity/src/infinite/conversion.jl:9
 [2] oftype(::Infinite, ::Int64) at ./essentials.jl:366
 [3] zero(::Infinite) at ./number.jl:265
 [4] iszero(::Infinite) at ./number.jl:40
 [5] top-level scope at REPL[4]:1
```