### PR TITLE
Fix `parse(::Type{InfExtendedTime}, ...)`

### DIFF
--- a/src/infextendedtime/parse.jl
+++ b/src/infextendedtime/parse.jl
@@ -5,3 +5,11 @@ function Base.tryparse(::Type{InfExtendedTime{T}}, str::AbstractString) where T
   end
   return val !== nothing ? InfExtendedTime{T}(val) : nothing
 end
+
+function Base.parse(::Type{InfExtendedTime{T}}, str::AbstractString) where T
+  val = tryparse(InfExtendedTime{T}, str)
+  if val === nothing
+    throw(ArgumentError("Unable to parse \"$str\" as $(InfExtendedTime{T})"))
+  end
+  return val
+end

--- a/test/infextendedreal.jl
+++ b/test/infextendedreal.jl
@@ -100,6 +100,16 @@
         val = tryparse(InfExtendedReal{Int}, "a")
         @test val == nothing
         @test val isa Nothing
+
+        val = parse(InfExtendedReal{Int}, "∞")
+        @test val == ∞
+        @test val isa InfExtendedReal{Int}
+
+        val = parse(InfExtendedReal{Int}, "1")
+        @test val == 1
+        @test val isa InfExtendedReal{Int}
+
+        @test_throws ArgumentError parse(InfExtendedReal{Int}, "a")
     end
 
     @testset "comparisons" begin

--- a/test/infextendedtime.jl
+++ b/test/infextendedtime.jl
@@ -109,6 +109,16 @@ test_time = Time(1, 1, 1, 1)
         val = tryparse(InfExtendedTime{Date}, "a")
         @test val == nothing
         @test val isa Nothing
+
+        val = parse(InfExtendedTime{Date}, "∞")
+        @test val == ∞
+        @test val isa InfExtendedTime{Date}
+
+        val = parse(InfExtendedTime{Date}, "2012-01-01")
+        @test val == Date(2012, 1, 1)
+        @test val isa InfExtendedTime{Date}
+
+        @test_throws ArgumentError parse(InfExtendedTime{Date}, "a")
     end
 
     @testset "Comparison" begin

--- a/test/infinite.jl
+++ b/test/infinite.jl
@@ -48,6 +48,10 @@
         @test tryparse(Infinite, "∞") === ∞
         @test tryparse(Infinite, "-∞") === -∞
         @test tryparse(Infinite, "1") === nothing
+
+        @test parse(Infinite, "∞") === ∞
+        @test parse(Infinite, "-∞") === -∞
+        @test_throws ArgumentError parse(Infinite, "1")
     end
 
     @testset "Comparison" begin


### PR DESCRIPTION
Fixes: https://github.com/cjdoris/Infinity.jl/issues/27. Something I missed in #22.